### PR TITLE
refactor(event-sourcing): remove TRANSACTION_RETRY_ATTEMPTED

### DIFF
--- a/src/main/java/br/com/wallet/project/adapter/out/persistence/WalletEventPersistenceAdapter.java
+++ b/src/main/java/br/com/wallet/project/adapter/out/persistence/WalletEventPersistenceAdapter.java
@@ -1,0 +1,92 @@
+package br.com.wallet.project.adapter.out.persistence;
+
+import br.com.wallet.project.adapter.out.persistence.jpa.JpaWalletEventRepository;
+import br.com.wallet.project.application.port.out.WalletEventRepository;
+import br.com.wallet.project.domain.event.WalletEvent;
+import br.com.wallet.project.domain.event.WalletEventType;
+import br.com.wallet.project.shared.mapper.WalletEventMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+/**
+ * Driven adapter: implements {@link WalletEventRepository} using JPA + PostgreSQL.
+ *
+ * <p>All writes are append-only. Duplicate eventIds are silently dropped
+ * (idempotent save) to support at-least-once delivery from Kafka.
+ */
+@Slf4j
+@Repository
+@RequiredArgsConstructor
+public class WalletEventPersistenceAdapter implements WalletEventRepository {
+
+    private final JpaWalletEventRepository jpaWalletEventRepository;
+
+    @Override
+    public WalletEvent save(WalletEvent event) {
+        if (jpaWalletEventRepository.existsByEventId(event.getEventId())) {
+            log.warn("Duplicate event detected and skipped: eventId={} type={}",
+                    event.getEventId(), event.getEventType());
+            return event;
+        }
+        var saved = jpaWalletEventRepository.save(WalletEventMapper.toEntity(event));
+        log.debug("Event persisted: eventId={} type={} aggregateId={}",
+                saved.getEventId(), saved.getEventType(), saved.getAggregateId());
+        return WalletEventMapper.toDomain(saved);
+    }
+
+    @Override
+    public List<WalletEvent> findByAggregateId(String aggregateId) {
+        return jpaWalletEventRepository
+                .findByAggregateIdOrderByOccurredAtAsc(aggregateId)
+                .stream()
+                .map(WalletEventMapper::toDomain)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public List<WalletEvent> findByCorrelationId(UUID correlationId) {
+        return jpaWalletEventRepository
+                .findByCorrelationIdOrderByOccurredAtAsc(correlationId)
+                .stream()
+                .map(WalletEventMapper::toDomain)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public Optional<WalletEvent> findByEventId(UUID eventId) {
+        return jpaWalletEventRepository
+                .findByEventId(eventId)
+                .map(WalletEventMapper::toDomain);
+    }
+
+    @Override
+    public List<WalletEvent> findByAggregateIdAndEventType(String aggregateId,
+                                                            WalletEventType eventType) {
+        return jpaWalletEventRepository
+                .findByAggregateIdAndEventTypeOrderByOccurredAtAsc(aggregateId, eventType)
+                .stream()
+                .map(WalletEventMapper::toDomain)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public List<WalletEvent> findByDateRange(LocalDateTime start, LocalDateTime end) {
+        return jpaWalletEventRepository
+                .findByDateRange(start, end)
+                .stream()
+                .map(WalletEventMapper::toDomain)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public boolean existsByEventId(UUID eventId) {
+        return jpaWalletEventRepository.existsByEventId(eventId);
+    }
+}

--- a/src/main/java/br/com/wallet/project/adapter/out/persistence/entity/WalletEventEntity.java
+++ b/src/main/java/br/com/wallet/project/adapter/out/persistence/entity/WalletEventEntity.java
@@ -1,0 +1,93 @@
+package br.com.wallet.project.adapter.out.persistence.entity;
+
+import br.com.wallet.project.domain.event.WalletEventType;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+import java.time.LocalDateTime;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * JPA entity that persists a {@link br.com.wallet.project.domain.event.WalletEvent}
+ * into the {@code wallet_events} append-only table.
+ *
+ * <p>This table is the authoritative event log. The {@code wallets} and
+ * {@code transactions} tables are read-model projections kept in sync by the
+ * domain strategies (DepositStrategy, WithdrawStrategy, TransferStrategy).
+ */
+@Entity
+@Table(name = "wallet_events",
+        indexes = {
+                @Index(name = "idx_wallet_events_aggregate_id",   columnList = "aggregateId"),
+                @Index(name = "idx_wallet_events_event_type",     columnList = "eventType"),
+                @Index(name = "idx_wallet_events_occurred_at",    columnList = "occurredAt"),
+                @Index(name = "idx_wallet_events_correlation_id", columnList = "correlationId"),
+        })
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class WalletEventEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    /** Globally unique event identifier — used for idempotency and dedup. */
+    @Column(nullable = false, unique = true, updatable = false)
+    private UUID eventId;
+
+    /**
+     * Logical aggregate identifier.
+     * For DEPOSIT / WITHDRAW: the wallet owner's userId.
+     * For TRANSFER: the fromUserId (initiating side).
+     */
+    @Column(nullable = false, updatable = false)
+    private String aggregateId;
+
+    @Column(nullable = false, updatable = false)
+    @Builder.Default
+    private String aggregateType = "WALLET";
+
+    @Column(nullable = false, updatable = false)
+    @Enumerated(EnumType.STRING)
+    private WalletEventType eventType;
+
+    @Column(nullable = false, updatable = false)
+    @Builder.Default
+    private int eventVersion = 1;
+
+    /**
+     * Domain payload stored as JSONB.
+     * Contains the full business data for the event (amounts, userIds, balances…).
+     */
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(nullable = false, columnDefinition = "jsonb", updatable = false)
+    private Map<String, Object> payload;
+
+    /**
+     * Technical metadata stored as JSONB.
+     * Contains Kafka partition/offset, thread name, etc.
+     */
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(columnDefinition = "jsonb", updatable = false)
+    private Map<String, Object> metadata;
+
+    /** Links HTTP request → Kafka publish → consumer processing in one trace. */
+    @Column(updatable = false)
+    private UUID correlationId;
+
+    /** The eventId that triggered this event (request → completion chain). */
+    @Column(updatable = false)
+    private UUID causationId;
+
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime occurredAt;
+
+    @Column(nullable = false, updatable = false)
+    @Builder.Default
+    private LocalDateTime createdAt = LocalDateTime.now();
+}

--- a/src/main/java/br/com/wallet/project/adapter/out/persistence/jpa/JpaWalletEventRepository.java
+++ b/src/main/java/br/com/wallet/project/adapter/out/persistence/jpa/JpaWalletEventRepository.java
@@ -1,0 +1,42 @@
+package br.com.wallet.project.adapter.out.persistence.jpa;
+
+import br.com.wallet.project.adapter.out.persistence.entity.WalletEventEntity;
+import br.com.wallet.project.domain.event.WalletEventType;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface JpaWalletEventRepository extends JpaRepository<WalletEventEntity, Long> {
+
+    /** Replay all events for a single aggregate, ordered chronologically. */
+    List<WalletEventEntity> findByAggregateIdOrderByOccurredAtAsc(String aggregateId);
+
+    /** Find a specific event by its globally unique eventId. */
+    Optional<WalletEventEntity> findByEventId(UUID eventId);
+
+    /** All events in a date range — useful for audits and projections rebuilds. */
+    @Query("""
+            SELECT e FROM WalletEventEntity e
+            WHERE e.occurredAt >= :start
+              AND e.occurredAt <= :end
+            ORDER BY e.occurredAt ASC
+            """)
+    List<WalletEventEntity> findByDateRange(
+            @Param("start") LocalDateTime start,
+            @Param("end") LocalDateTime end);
+
+    /** Trace all events that share the same correlationId (full request trace). */
+    List<WalletEventEntity> findByCorrelationIdOrderByOccurredAtAsc(UUID correlationId);
+
+    /** All events for an aggregate filtered by type (e.g. all DEPOSITs for a user). */
+    List<WalletEventEntity> findByAggregateIdAndEventTypeOrderByOccurredAtAsc(
+            String aggregateId, WalletEventType eventType);
+
+    /** Check dedup by eventId before persisting. */
+    boolean existsByEventId(UUID eventId);
+}

--- a/src/main/java/br/com/wallet/project/application/port/out/WalletEventRepository.java
+++ b/src/main/java/br/com/wallet/project/application/port/out/WalletEventRepository.java
@@ -1,0 +1,39 @@
+package br.com.wallet.project.application.port.out;
+
+import br.com.wallet.project.domain.event.WalletEvent;
+import br.com.wallet.project.domain.event.WalletEventType;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+/**
+ * Driven port: append-only event store contract.
+ *
+ * <p>Callers only ever append events — never update or delete them.
+ * Querying is used for projections, audits, and replay.
+ */
+public interface WalletEventRepository {
+
+    /** Append a single event. Idempotent: duplicate eventIds are silently ignored. */
+    WalletEvent save(WalletEvent event);
+
+    /** Replay the full history of an aggregate in chronological order. */
+    List<WalletEvent> findByAggregateId(String aggregateId);
+
+    /** Retrieve all events linked by the same HTTP/Kafka correlation. */
+    List<WalletEvent> findByCorrelationId(UUID correlationId);
+
+    /** Find a single event by its unique eventId. */
+    Optional<WalletEvent> findByEventId(UUID eventId);
+
+    /** All events for an aggregate of a specific type. */
+    List<WalletEvent> findByAggregateIdAndEventType(String aggregateId, WalletEventType eventType);
+
+    /** Range query — useful for rebuilding projections or auditing a window. */
+    List<WalletEvent> findByDateRange(LocalDateTime start, LocalDateTime end);
+
+    /** Guard against double-persisting the same event. */
+    boolean existsByEventId(UUID eventId);
+}


### PR DESCRIPTION
 and WalletEventOutboxService
MIME-Version: 1.0
Content-Type: text/plain; charset=UTF-8
Content-Transfer-Encoding: 8bit

Motivation
----------
TRANSACTION_RETRY_ATTEMPTED events were recorded once per Kafka retry attempt. In this domain, errors are deterministic (insufficient funds, wallet not found) so every retry fails with the same reason — resulting in N identical events. The retryCount field in *_PERMANENTLY_FAILED already captures how many attempts were made, and the reason field identifies the root cause. WalletEventOutboxService (REQUIRES_NEW) was introduced solely to persist those retry events through a rolled-back transaction — no longer needed.

Changes
-------
WalletEventType.java
  Remove TRANSACTION_RETRY_ATTEMPTED

WalletEventFactory.java
  Remove retryAttempted() method

WalletEventOutboxService.java
  Deleted entirely

TransactionService.java
  Remove WalletEventOutboxService injection
  Remove IDEMPOTENCY_DUPLICATE_DETECTED save (was rolled back anyway;
    *_PERMANENTLY_FAILED.reason already captures the duplicate error message)
  Simplify processTransaction javadoc

KafkaTransactionConsumer.java
  Remove WalletEventOutboxService injection
  Simplify catch block to log + re-throw only
  Update @DltHandler javadoc (timeline now: REQUESTED -> PERMANENTLY_FAILED)

WalletEventFactoryTest.java
  Remove all retryAttempted_* tests

EventSourcingFunctionalTest.java
  Remove ES-13, ES-14
  Remove TRANSACTION_RETRY_ATTEMPTED assertions from ES-02, ES-03, ES-04, ES-05, ES-06, ES-07
  Simplify DisplayNames for ES-05, ES-06, ES-07